### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/cache/src/main/resources/readme.md
+++ b/cache/src/main/resources/readme.md
@@ -1,14 +1,14 @@
-#Dubbo缓存插件
+# Dubbo缓存插件
 
 
-##一、插件概述
+## 一、插件概述
 该插件主要是完善Dubbo缓存方案，由于Dubbo提供的默认缓存方案比较基础，只是提供了简单的本地缓存方案，而不具备和第三方
 缓存组件集成。本插件通过扩展实现了Dubbo的`Cache`和`CacheFactory`接口，和Redis,Memcached以及本地缓存组件Ehcache
 进行集成。
-##二、如何引用缓存
+## 二、如何引用缓存
 对于dubbo的配置之前写过一篇比较详细的内容进行介绍，这里不在对主要其内容进行重复介绍，如要了解可以到[http://bbs.dubboclub.net/read-4.html](http://bbs.dubboclub.net/read-4.html)去了解
 这里只对如何引用缓存进行介绍。
-###1、通过XML标签配置
+### 1、通过XML标签配置
     <!--lang:xml-->
     <!--表示服务提供端对所有暴露的服务都添加缓存功能-->
     <dubbo:provider cache="${cacheKey}"/>
@@ -21,7 +21,7 @@
      <!--表示对某个服务内的某个方法添加缓存功能-->
     <dubbo:method ... cache="${cacheKey}"/>
     
-###2、通过Properties文件配置
+### 2、通过Properties文件配置
     <!--lang:java-->
     #同<dubbo:provider..
     dubbo.service.cache=${cacheKey}
@@ -32,15 +32,15 @@
     #同<dubbo:reference..
     dubbo.reference.${beanId}.cache=${cacheKey}
 
-###补充
+### 补充
 上面配置内容中都有一个${cacheKey}这个只是一个占位符，具体配置的是填入你想用的缓存组件即可，那么问题来了，dubbo提供哪些缓存实现呢？
 
-####dubbo默认提供的缓存实现
+#### dubbo默认提供的缓存实现
 > threadlocal：它的实现类是ThreadLocalCacheFactory，一看就知道是一个线程级别的缓存了<br>
   lru：它的实现类是LruCacheFactory，是一个基于本地内存的LRU算法的缓存<br>
   jcache：它的实现类是JCacheFactory，是一个基于JCache的缓存实现<br>
 
-####当前cache插件提供哪些实现
+#### 当前cache插件提供哪些实现
         
 > redis：它的实现类是RedisCacheFactory，是集成了Redis的缓存实现<br>
   memcached：它的实现类是MCCacheFactory，是集成了Memcached缓存实现<br>
@@ -49,9 +49,9 @@
 
 **如果你的项目引用了cache插件，那么${cacheKey}的可选值是threadlocal,lru,jcache,redis,memcached,ehcache,mixcache**
 
-##三、如何使用该缓存插件
+## 三、如何使用该缓存插件
 该插件提供了四种缓存实现，那么针对这四种缓存实现需要做哪些配置呢？
-###1、配置信息加载途径
+### 1、配置信息加载途径
 该插件对缓存配置加载提供了三种途径<br>
 - **第一种、集成到dubbo.properties配置文件中**<br>
 - **第二种、通过在dubbo.properties配置cache.properties.file属性来指明缓存配置文件路径**<br>
@@ -61,7 +61,7 @@
 
 **下面所介绍的配置信息均是配置在上述配置文件中**
 
-###2、使用Redis缓存需要配置的信息
+### 2、使用Redis缓存需要配置的信息
     
     <!--lang-->
 	#【必填】配置redis连接地址，ip:port格式，如果是redis集群，可以是ip1:port1,ip2:port2....ipn:portn通过英文逗号将各个连接地址分开
@@ -97,7 +97,7 @@
 	#【选填】默认值pool
     cache.redis.jmxNamePrefix
     
-###3、使用memcached缓存需要配置的信息
+### 3、使用memcached缓存需要配置的信息
     <!--lang-->
 	#【必填】配置redis连接地址，ip:port格式，如果是redis集群，可以是ip1:port1,ip2:port2....ipn:portn通过英文逗号将各个连接地址分开
     cache.memcached.connect    
@@ -128,9 +128,9 @@
 	#【选填】默认1000l
     cache.memcached.checkSessionTimeoutInterval
 
-###5、使用ehcache缓存需要配置信息
+### 5、使用ehcache缓存需要配置信息
 对于ehcache的配置除了上面配置外，由于ehcache自己有一套配置文件，所以也支持通过它自身的xml配置文件来配置
-####通过properties来配置
+#### 通过properties来配置
     <!--lang-->
     #默认值true
     cache.ehcache.updateCheck
@@ -182,12 +182,12 @@
     #默认值null
     cache.ehcache.maxBytesLocalDisk
     
-####通过ehcache自带的XML方式配置
+#### 通过ehcache自带的XML方式配置
     <!--lang-->
 	#通过在配置文件中配置ehcache的XML文件路径 文件路径配置可以是:file:C:/cache/cache.xml文件系统格式，或者是:classpath:cache.xml的classpath路径
     cache.ehcache.configuration 
 
-###6、使用mixcache缓存需要配置的信息
+### 6、使用mixcache缓存需要配置的信息
      <!--lang-->
 	#【必填】配置组合的缓存实现名称，可选值有threadlocal,lru,jcache,redis,memcached,ehcache，必须配置两个缓存实现，同英文逗号隔开，例如cache.mix=ehcache,redis
      cache.mix
@@ -196,7 +196,7 @@
 > 这种情况如果引用了两个缓存实现，那么需要对这两个缓存实现进行配置。，比如上面的cache.mix=ehcache,redis，那么你就需要对ehcache和redis两种缓存实现进行配置
 
     
-##四、对于缓存方法黑/白名单
+## 四、对于缓存方法黑/白名单
 上面对开启dubbo缓存方式知道，可以对全局服务开启缓存，也可以对指定的接口来开启缓存，也可以对某个具体的方法开启缓存，为了能够更加智能的对某个方法的执行结果进行缓存
 该插件添加了缓存方法黑/白名单的功能
 
@@ -208,40 +208,40 @@
 
 > 当缓存插件拦截到当前执行方法不在黑名单里面，并且在白名单里面那么将对该方法的结果进行缓存，否则不进行缓存
 
-##五、对缓存超时时间配置
-###1、对全局缓存有效时间配置
+## 五、对缓存超时时间配置
+### 1、对全局缓存有效时间配置
     
     <!--lang-->
 	#单位秒 默认值60*10,十分钟
     cache.default.expire 
     
-###2、对某个接口的所有方法设置缓存有效时间
+### 2、对某个接口的所有方法设置缓存有效时间
     <!--lang-->
 	#单位秒 默认值cache.${cacheKey}.default.expire
     cache.interfacefullname.expire 
-###3、对某个接口的某个方法设置缓存有效时间
+### 3、对某个接口的某个方法设置缓存有效时间
     <!--lang-->
 	##单位秒 默认值cache.${cacheKey}.interfacefullname.expire
     cache.interfacefullname.methodname.expire 
 
-##六、对某个缓存实现设置属于其私有的有效时间
+## 六、对某个缓存实现设置属于其私有的有效时间
 下面对cacheKey可取的值有redis,memcached,ehcache
 
 redis：是对redis的缓存实现设置缓存有效时间
 memcached:是对memcached的缓存实现设置缓存有效时间
 ehcached:是对ehcache的缓存实现设置有效时间
 
-###1、对全局缓存有效时间配置
+### 1、对全局缓存有效时间配置
 
     <!--lang-->
 	#单位秒 默认值cache.default.expire
     cache.${cacheKey}.default.expire 
 
-###2、对某个接口的所有方法设置缓存有效时间
+### 2、对某个接口的所有方法设置缓存有效时间
     <!--lang-->
 	#单位秒 默认值cache.interfacefullname.expire
     cache.${cacheKey}.interfacefullname.expire 
-###3、对某个接口的某个方法设置缓存有效时间
+### 3、对某个接口的某个方法设置缓存有效时间
     <!--lang-->
 	#单位秒 默认值cache.interfacefullname.methodname.expire
     cache.${cacheKey}.interfacefullname.methodname.expire 

--- a/circuitbreaker/src/main/resources/readme.md
+++ b/circuitbreaker/src/main/resources/readme.md
@@ -1,5 +1,5 @@
-#服务降级方案实现
-##当前情况
+# 服务降级方案实现
+## 当前情况
 Dubbo支持服务降级，并且支持当服务出现异常的时候进行服务降级处理，但是存在一下几个缺陷
 
 
@@ -9,31 +9,31 @@ Dubbo支持服务降级，并且支持当服务出现异常的时候进行服务
 
 针对上面两个问题，我们需要达到的目的是：当远程服务真的出现宕机的时候，消费端不要再进行远程调用，而是直接降级处理，并且消费端能够定时的检查服务是否恢复，从而自动下线降级服务，恢复调用远程服务。
 
-##具体实现
+## 具体实现
 通过Dubbo的Filter对Dubbo进行扩展，从而使得每次服务发起调用都可以得到监控，从而可以监控每次服务的调用。
 
 **对自动判断服务提供端是否宕机**：通过一个记录器对每个方法出现RPC异常进行记录，并且可以配置在某个时间段内连续出现都少个异常可判定为服务提供端出现了宕机，从而进行服务降级。
 
 **自动恢复远程服务调用**：通过配置检查服务的频率来达到定时检查远程服务是否可用，从而去除服务降级。
 
-##降级相关配置
+## 降级相关配置
 降级配置分配为应用级别，接口级别，方法级别
-###一、动态配置
+### 一、动态配置
     可以通过dubbo-admin(官方的基本不可用)动态对某个接口或者方法配置如下参数以达到动态对接口后者方法配置
     circuit.break：支持接口和方法级别
     retry.frequency: 同时
     break.limit: 同上
-###二、应用级别
+### 二、应用级别
     <!--lang:java-->
     dubbo.reference.default.break.limit：该参数是配置一个方法在指定时间内出现多少个异常则判断为服务提供方宕机
     dubbo.reference.default.retry.frequency：该参数配置重试频率，比如配置100，则表示没出现一百次异常则尝试一下远程服务是否可用
     dubbo.reference.circuit.break:服务降级功能开关，默认是false，表示关闭状态，可以配置为true
-###三、接口级别
+### 三、接口级别
     <!--lang:java-->
     dubbo.reference.${fullinterfacename}.break.limit：同上面dubbo.reference.default-break-limit，指定某个接口
     dubbo.reference.${fullinterfacename}.retry.frequency:同上面
     dubbo.reference.${fullinterfacename}.circuit.break:服务降级功能开关，默认是false，表示关闭状态，可以配置为true
-###四、方法级别
+### 四、方法级别
     <!--lang:java-->
     dubbo.reference.${fullinterfacename}.${methodName}.break.limit：同上面dubbo.reference.default-break-limit，指定某个接口的某个方法
     dubbo.reference.${fullinterfacename}.${methodName}.retry.frequency:同上面dubbo.reference.default-retry-frequency，指定某个接口的某个方法
@@ -45,7 +45,7 @@ dubbo.properties具体在哪里，默认是在classpath根目录，也可以通�
 
 
 
-##降级服务实现
+## 降级服务实现
 默认情况的服务降级是直接返回一个异常（CircuitBreakerException），也可以在消费端对某个远程接口提供一个默认实现，作为降级方案。
 
 具体规则如下：
@@ -54,6 +54,6 @@ dubbo.properties具体在哪里，默认是在classpath根目录，也可以通�
 
 
 
-##相关日志名
+## 相关日志名
 **CIRCUITBREAKER**
 **CIRCUITBREAKER-STATISTICS**

--- a/dubbo-generator/src/main/resources/readme.md
+++ b/dubbo-generator/src/main/resources/readme.md
@@ -1,4 +1,4 @@
-##dubbo客户端自动生成器
+## dubbo客户端自动生成器
 在大部分业务场景和产线部署的时候会发现要引用一个dubbo远程服务只需要进行如下的配置即可：
 
     <!--lang:xml-->
@@ -8,9 +8,9 @@
 所以我这里要做的就是把dubbo从spring中剥离出来，提供一种更加便捷的方式获取远程服务。同时提供更加便捷的方式对远程服务的增强
 提供AOP的方式切入的服务的具体执行中。
 
-##Getting start
+## Getting start
 
-###引入工具包
+### 引入工具包
     
     <!--lang:xml-->
      <dependency>
@@ -18,9 +18,9 @@
          <artifactId>dubbo-generator</artifactId>
          <version>${dubboclub.generator.version}</version>
       </dependency>
-###引入远程服务新方式
+### 引入远程服务新方式
 
-####延迟加载方式
+#### 延迟加载方式
     <!--lang:java-->
     ClientFacade client = DubboClientWrapper.getWrapper(ClientFacade.class);
     ClientFacade client = DubboClientWrapper.getWrapper(ClientFacade.class, InvokeHandler.class);
@@ -30,7 +30,7 @@
 DubboClientWrapper提供了上面四种方式获取dubbo远程服务。其中"clientId"这是指定该服务的id(和通过spring的<dubbo:reference id=""/> 中id一样)，InvokeHandler(这是一个接口，必须传入这个类的实现类)是指定对这个client的增强类。
 clientId的默认值是"[FacadeClassFullName]",InvokeHandler的默认值是DefaultInvokeHandler,该handler只进行简单的请求日志记录，记录在logger name为DUBBO_INTEGRATION的日志中。
 
-###预加载
+### 预加载
 上面的方式是在对某个Client第一次使用的时候才会加载这个远程服务，并且创建对应的服务实体。这样可能对于第一次请求的时候效率上会有影响。也可以通过该配置spring的方式来预先加载
 
     <!--lang:xml-->
@@ -46,22 +46,22 @@ clientId的默认值是"[FacadeClassFullName]",InvokeHandler的默认值是Defau
 通过上面方式注入，对于引用服务可以通过两种方式来引用dubbo的远程服务。第一种还是通过DubboClientWrapper的静态方法获取对应远程服务实体。也可以通过spring的@Atowire注解
 需要注意的是，这种预加载，并没地方设置clientid以及invokeHandler，此处全部采用默认的设置方式，当然也提供其他设置途径，下面会进行介绍。
 
-##InvokeHandler设置
+## InvokeHandler设置
 某个InvokeHandler类只会实例化一次，每个dubbo的客户端可以设置不同的InvokeHandler以满足不同接口不同的需求。如果设置呢？
 
-###全局InvokeHandler设置
+### 全局InvokeHandler设置
 全局的设置可以通过`DubboClientWrapper.setDefaultHandler(Class<? extends InvokeHandler> handlerClass)`设置全局的默认handler，该方法只能调用一次，如果调用两次则会出现异常。
 除了上面编程方式指定默认全局的handler，还可以通过在dubbo.properties中通过配置`dubbo.wrapper.default.handler`参数配置Handler的类全名来指定全局默认的handler。
 如果通过dubbo.properties配置了`dubbo.wrapper.default.handler`这个参数，也通过`DubboClientWrapper.setDefaultHandler(Class<? extends InvokeHandler> handlerClass)`
 方法设置了默认handler，最终是以调用`DubboClientWrapper.setDefaultHandler`为准，在dubbo.properties则会被覆盖。
 
-###给某个dubbo接口指定Handler
+### 给某个dubbo接口指定Handler
 这里同样也提供两种方式，第一种方式则是上面延迟加载方式通过调用`DubboClientWrapper.getWrapper`带有InvokeHandler参数的方法来给某个client指定某一个handler。
 
 同样也可以通过在dubbo.properties中通过配置来指定。
 通过配置dubbo.wrapper.{clientId}.handler参数配置Handler的类全名，其中clientId默认是"[facadeclassfullname]"。
 
-##最佳实践
+## 最佳实践
 比如现在有一个net.dubboclub.QueryUserInfoFacade接口
 
     <!--lang:java-->

--- a/netty4/src/main/resources/readme.md
+++ b/netty4/src/main/resources/readme.md
@@ -1,9 +1,9 @@
-##Dubbo Netty4通信层插件
+## Dubbo Netty4通信层插件
 由于dubbo官方当前版本是支持Netty3的，没有对Netty4的支持，要想使用Netty4的dubbo，只能使用dubbox，但是需要
 将dubbo的整体都替换成dubbox，这样很不方便，于是就基于dubbo的extension方式实现了一个netty4的插件，不需要
 对你当前的项目过多的调整只需要引入插件的jar以及加入相关配置即可。
 
-##引用插件的jar包
+## 引用插件的jar包
     <!-- lang:xml-->
     <dependency>
          <groupId>net.dubboclub</groupId>
@@ -11,7 +11,7 @@
          <version>${dubboclub.netty4.version}</version>
     </dependency>
 
-##客户端加入Netty4插件
+## 客户端加入Netty4插件
 可以在dubbo的xml中对标签dubbo:reference 添加client属性，值为netty4
 
     <!-- lang:xml-->
@@ -23,7 +23,7 @@ dubbo.reference.client=netty4
 
 这样就对所有的订阅服务都走了netty4的通信了。
 
-##服务端加入Netty4插件
+## 服务端加入Netty4插件
 
 同样可以通过xml进行配置,在标签dubbo:provider添加server属性，值为netty4
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
